### PR TITLE
wip: better nokogiri usage

### DIFF
--- a/app/helpers/admin/trends/statuses_helper.rb
+++ b/app/helpers/admin/trends/statuses_helper.rb
@@ -5,7 +5,7 @@ module Admin::Trends::StatusesHelper
     text = if status.local?
              status.text.split("\n").first
            else
-             Nokogiri::HTML(status.text).css('html > body > *').first&.text
+             Nokogiri::HTML5(status.text).css('html > body > *').first&.text
            end
 
     return '' if text.blank?

--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -24,7 +24,7 @@ class EmojiFormatter
   def to_s
     return html if custom_emojis.empty? || html.blank?
 
-    tree = Nokogiri::HTML.fragment(html)
+    tree = Nokogiri::HTML5.fragment(html)
     tree.xpath('./text()|.//text()[not(ancestor[@class="invisible"])]').to_a.each do |node|
       i                     = -1
       inside_shortname      = false
@@ -43,8 +43,8 @@ class EmojiFormatter
 
           next unless (char_after.nil? || !DISALLOWED_BOUNDING_REGEX.match?(char_after)) && (emoji = emoji_map[shortcode])
 
-          result << Nokogiri::XML::Text.new(text[last_index..shortname_start_index - 1], tree.document) if shortname_start_index.positive?
-          result << Nokogiri::HTML.fragment(tag_for_emoji(shortcode, emoji))
+          result << tree.document.create_text_node(text[last_index..shortname_start_index - 1]) if shortname_start_index.positive?
+          result << tree.document.fragment(tag_for_emoji(shortcode, emoji))
 
           last_index = i + 1
         elsif text[i] == ':' && (i.zero? || !DISALLOWED_BOUNDING_REGEX.match?(text[i - 1]))
@@ -53,7 +53,7 @@ class EmojiFormatter
         end
       end
 
-      result << Nokogiri::XML::Text.new(text[last_index..], tree.document)
+      result << tree.document.create_text_node(text[last_index..])
       node.replace(result)
     end
 

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -157,11 +157,11 @@ class LinkDetailsExtractor
   end
 
   def title
-    html_entities_decode(structured_data&.headline || opengraph_tag('og:title') || document.xpath('//title').map(&:content).first)&.strip
+    html_entities.decode(structured_data&.headline || opengraph_tag('og:title') || document.xpath('//title').map(&:content).first)&.strip
   end
 
   def description
-    html_entities_decode(structured_data&.description || opengraph_tag('og:description') || meta_tag('description'))
+    html_entities.decode(structured_data&.description || opengraph_tag('og:description') || meta_tag('description'))
   end
 
   def published_at
@@ -181,7 +181,7 @@ class LinkDetailsExtractor
   end
 
   def provider_name
-    html_entities_decode(structured_data&.publisher_name || opengraph_tag('og:site_name'))
+    html_entities.decode(structured_data&.publisher_name || opengraph_tag('og:site_name'))
   end
 
   def provider_url
@@ -189,7 +189,7 @@ class LinkDetailsExtractor
   end
 
   def author_name
-    html_entities_decode(structured_data&.author_name || opengraph_tag('og:author') || opengraph_tag('og:author:username'))
+    html_entities.decode(structured_data&.author_name || opengraph_tag('og:author') || opengraph_tag('og:author:username'))
   end
 
   def author_url
@@ -258,7 +258,7 @@ class LinkDetailsExtractor
 
       next if json_ld.blank?
 
-      structured_data = StructuredData.new(html_entities_decode(json_ld))
+      structured_data = StructuredData.new(html_entities.decode(json_ld))
 
       next unless structured_data.valid?
 
@@ -307,15 +307,6 @@ class LinkDetailsExtractor
     @detector ||= CharlockHolmes::EncodingDetector.new.tap do |detector|
       detector.strip_tags = true
     end
-  end
-
-  def html_entities_decode(string)
-    return if string.nil?
-
-    unicode_string = string.to_s.encode('UTF-8')
-    raise EncodingError, 'cannot convert string to valid UTF-8' unless unicode_string.valid_encoding?
-
-    html_entities.decode(unicode_string)
   end
 
   def html_entities

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -274,11 +274,21 @@ class LinkDetailsExtractor
   end
 
   def detect_encoding_and_parse_document
-    [detect_encoding, nil, header_encoding].uniq.each do |encoding|
-      document = Nokogiri::HTML(@html, nil, encoding)
-      return document if document.to_s.valid_encoding?
+    html = nil
+    encoding = nil
+
+    [detect_encoding, header_encoding].compact.each do |enc|
+      begin
+        html = @html.dup.force_encoding(enc)
+        encoding = enc if html.valid_encoding?
+      rescue Encoding::UndefinedConversionError
+        next
+      end
     end
-    Nokogiri::HTML(@html, nil, 'UTF-8')
+
+    html = @html unless encoding
+
+    Nokogiri::HTML5(html, nil, encoding)
   end
 
   def detect_encoding

--- a/app/lib/plain_text_formatter.rb
+++ b/app/lib/plain_text_formatter.rb
@@ -16,7 +16,7 @@ class PlainTextFormatter
     if local?
       text
     else
-      node = Nokogiri::HTML.fragment(insert_newlines)
+      node = Nokogiri::HTML5.fragment(insert_newlines)
       # Elements that are entirely removed with our Sanitize config
       node.xpath('.//iframe|.//math|.//noembed|.//noframes|.//noscript|.//plaintext|.//script|.//style|.//svg|.//xmp').remove
       node.text.chomp

--- a/app/models/account/field.rb
+++ b/app/models/account/field.rb
@@ -73,10 +73,10 @@ class Account::Field < ActiveModelSerializers::Model
   end
 
   def extract_url_from_html
-    doc = Nokogiri::HTML(value).at_xpath('//body')
+    doc = Nokogiri::HTML5.fragment(value)
 
     return if doc.nil?
-    return if doc.children.size > 1
+    return if doc.children.size != 1
 
     element = doc.children.first
 

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -80,7 +80,7 @@ class FetchLinkCardService < BaseService
     urls = if @status.local?
              @status.text.scan(URL_PATTERN).map { |array| Addressable::URI.parse(array[1]).normalize }
            else
-             document = Nokogiri::HTML(@status.text)
+             document = Nokogiri::HTML5(@status.text)
              links = document.css('a')
 
              links.filter_map { |a| Addressable::URI.parse(a['href']) unless skip_link?(a) }.filter_map(&:normalize)

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -29,7 +29,7 @@ class FetchLinkCardService < BaseService
     end
 
     attach_card if @card&.persisted?
-  rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, EncodingError, ActiveRecord::RecordInvalid => e
+  rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Encoding::UndefinedConversionError, ActiveRecord::RecordInvalid => e
     Rails.logger.debug { "Error fetching link #{@original_url}: #{e}" }
     nil
   end

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -25,7 +25,7 @@ class FetchOEmbedService
     return if html.nil?
 
     @format = @options[:format]
-    page    = Nokogiri::HTML(html)
+    page    = Nokogiri::HTML5(html)
 
     if @format.nil? || @format == :json
       @endpoint_url ||= page.at_xpath('//link[@type="application/json+oembed"]|//link[@type="text/json+oembed"]')&.attribute('href')&.value

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -73,7 +73,7 @@ class FetchResourceService < BaseService
   end
 
   def process_html(response)
-    page      = Nokogiri::HTML(response.body_with_limit)
+    page      = Nokogiri::HTML5(response.body_with_limit)
     json_link = page.xpath('//link[@rel="alternate"]').find { |link| ACTIVITY_STREAM_LINK_TYPES.include?(link['type']) }
 
     process(json_link['href'], terminal: true) unless json_link.nil?

--- a/app/services/translate_status_service.rb
+++ b/app/services/translate_status_service.rb
@@ -100,7 +100,7 @@ class TranslateStatusService < BaseService
   end
 
   def unwrap_emoji_shortcodes(html)
-    fragment = Nokogiri::HTML.fragment(html)
+    fragment = Nokogiri::HTML5.fragment(html)
     fragment.css('span[translate="no"]').each do |element|
       element.remove_attribute('translate')
       element.replace(element.children) if element.attributes.empty?

--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -26,7 +26,7 @@ class VerifyLinkService < BaseService
   def link_back_present?
     return false if @body.blank?
 
-    links = Nokogiri::HTML5(@body).xpath('//a[contains(concat(" ", normalize-space(@rel), " "), " me ")]|//link[contains(concat(" ", normalize-space(@rel), " "), " me ")]')
+    links = Nokogiri::HTML5(@body).css("a[rel~='me'],link[rel~='me']")
 
     if links.any? { |link| link['href']&.downcase == @link_back.downcase }
       true

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -52,7 +52,7 @@ class Sanitize
                  :relative
                end
 
-      current_node.replace(Nokogiri::XML::Text.new(current_node.text, current_node.document)) unless LINK_PROTOCOLS.include?(scheme)
+      current_node.replace(current_node.document.create_text_node(current_node.text)) unless LINK_PROTOCOLS.include?(scheme)
     end
 
     UNSUPPORTED_ELEMENTS_TRANSFORMER = lambda do |env|

--- a/lib/tasks/emojis.rake
+++ b/lib/tasks/emojis.rake
@@ -13,7 +13,7 @@ def gen_border(codepoint, color)
     view_box[3] += 4
     svg['viewBox'] = view_box.join(' ')
   end
-  g = Nokogiri::XML::Node.new 'g', doc
+  g = doc.create_element('g')
   doc.css('svg > *').each do |elem|
     border_elem = elem.dup
 

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -192,8 +192,8 @@ RSpec.describe FetchLinkCardService do
         context 'when encoding problems appear in title tag' do
           let(:status) { Fabricate(:status, text: 'Check out http://example.com/latin1_posing_as_utf8_broken') }
 
-          it 'does not create a preview card' do
-            expect(status.preview_card).to be_nil
+          it 'creates a preview card anyway that replaces invalid bytes with U+FFFD (replacement char)' do
+            expect(status.preview_card.title).to eq("Tofu � l'orange")
           end
         end
       end

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe VerifyLinkService do
 
     before do
       stub_request(:head, 'https://redirect.me/abc').to_return(status: 301, headers: { 'Location' => ActivityPub::TagManager.instance.url_for(account) })
+      stub_request(:head, 'http://unrelated-site.com').to_return(status: 301)
       stub_request(:get, 'http://example.com').to_return(status: 200, body: html)
       subject.call(field)
     end
 
     context 'when a link contains an <a> back' do
       let(:html) do
-        <<-HTML
+        <<~HTML
           <!doctype html>
           <body>
             <a href="#{ActivityPub::TagManager.instance.url_for(account)}" rel="me">Follow me on Mastodon</a>
@@ -30,9 +31,9 @@ RSpec.describe VerifyLinkService do
       end
     end
 
-    context 'when a link contains an <a rel="noopener noreferrer"> back' do
+    context 'when a link contains an <a rel="me noopener noreferrer"> back' do
       let(:html) do
-        <<-HTML
+        <<~HTML
           <!doctype html>
           <body>
             <a href="#{ActivityPub::TagManager.instance.url_for(account)}" rel="me noopener noreferrer" target="_blank">Follow me on Mastodon</a>
@@ -47,7 +48,7 @@ RSpec.describe VerifyLinkService do
 
     context 'when a link contains a <link> back' do
       let(:html) do
-        <<-HTML
+        <<~HTML
           <!doctype html>
           <head>
             <link type="text/html" href="#{ActivityPub::TagManager.instance.url_for(account)}" rel="me" />
@@ -62,7 +63,7 @@ RSpec.describe VerifyLinkService do
 
     context 'when a link goes through a redirect back' do
       let(:html) do
-        <<-HTML
+        <<~HTML
           <!doctype html>
           <head>
             <link type="text/html" href="https://redirect.me/abc" rel="me" />
@@ -113,13 +114,28 @@ RSpec.describe VerifyLinkService do
 
     context 'when link has no `href` attribute' do
       let(:html) do
-        <<-HTML
+        <<~HTML
           <!doctype html>
           <head>
             <link type="text/html" rel="me" />
           </head>
           <body>
             <a rel="me" target="_blank">Follow me on Mastodon</a>
+          </body>
+        HTML
+      end
+
+      it 'does not mark the field as verified' do
+        expect(field.verified?).to be false
+      end
+    end
+
+    context 'when a link contains a link to an unexpected URL' do
+      let(:html) do
+        <<~HTML
+          <!doctype html>
+          <body>
+            <a href="http://unrelated-site.com" rel="me">Follow me on Unrelated Site</a>
           </body>
         HTML
       end
@@ -141,7 +157,7 @@ RSpec.describe VerifyLinkService do
 
     context 'when a link contains an <a> back' do
       let(:html) do
-        <<-HTML
+        <<~HTML
           <!doctype html>
           <body>
             <a href="https://profile.example.com/alice" rel="me">Follow me on Mastodon</a>


### PR DESCRIPTION
## Summary

I'd like to upgrade Mastodon to use the HTML5 parser everywhere, and use some better patterns where I see antipatterns have snuck into the codebase.

This PR is a WIP to try to get some CI feedback. I'll likely break this branch up into multiple pull requests upstream if it all works out.


## The work that needs to be done

Unfortunately, this change isn't always a straight substitution, and I'd like to clean up some code along the way.

Extracting themes of what could change to better use Nokogiri:

- add test coverage where it's missing
- parse as a `DocumentFragment` where Mastodon today parses as a `Document`
- remove or replace HTML4-parser-specific assumptions (like error message strings and document structure)

Files that need to be updated, along with some exploratory notes:

#### app/services/verify_link_service.rb

- [x] `#link_back_present?` should use CSS selectors instead of complex XPath
- [x] negative test coverage should be added to `spec/services/verify_link_service_spec.rb`

#### app/models/account/field.rb

- [x] `#extract_url_from_html` should parse as a fragment (not a document)
- [x] and check should be `children.size != 1` (not `> 1`)

#### app/services/fetch_link_card_service.rb and app/lib/link_details_extractor.rb

- [x] revert most of #30929 which is no longer necessary with Nokogiri's HTML5 parser
- [x] simplify changes from #30780 as Nokogiri's HTML5 parser falls back to UTF-8

#### app/helpers/admin/trends/statuses_helper.rb

- [x] verify that method is parsing documents (not fragments)
- [x] verify test coverage
- [x] change to HTML5 parser

#### app/lib/emoji_formatter.rb

- [x] verify that method is parsing fragments
- [x] verify test coverage
- [x] change to HTML5 parser
- [x] use `Document#create_text_node` instead of `XML::Text.new`
- [x] use `Document#fragment` instead of `Nokogiri::HTML.fragment`

#### app/lib/plain_text_formatter.rb

- [x] verify that method is parsing fragments
- [x] verify test coverage
- [x] change to HTML5 parser

#### app/services/fetch_oembed_service.rb

- [x] verify that method is parsing documents
- [x] verify test coverage
- [x] change to HTML5 parser

#### app/services/fetch_resource_service.rb

- [x] verify that method is parsing documents
- [x] verify test coverage
- [x] change to HTML5 parser

#### app/services/translate_status_service.rb

- [x] verify that method is parsing fragments
- [x] verify test coverage
- [x] change to HTML5 parser

#### lib/sanitize_ext/sanitize_config.rb

- [x] use `Document#create_text_node` instead of `XML::Text.new`

#### lib/tasks/emojis.rake

- [x] use `Document#create_element` instead of `XML::Node.new`
